### PR TITLE
Fix account deletion confirmation

### DIFF
--- a/enatega-multivendor-app/src/screens/Profile/Profile.js
+++ b/enatega-multivendor-app/src/screens/Profile/Profile.js
@@ -13,7 +13,8 @@ import {
   StatusBar,
   Text,
   Modal,
-  Pressable
+  Pressable,
+  Alert
 } from 'react-native'
 import { useMutation } from '@apollo/client'
 import gql from 'graphql-tag'
@@ -72,13 +73,26 @@ function Profile(props) {
     onError
   })
 
-  const onCompletedDeactivate = () => {
-    setDeleteModalVisible(false)
-    logout()
+  async function handleDeletedAccountConfirmation() {
+    await logout()
     navigation.reset({
       routes: [{ name: 'Main' }]
     })
-    FlashMessage({ message: t('accountDeactivated'), duration: 5000 })
+  }
+
+  const onCompletedDeactivate = () => {
+    setDeleteModalVisible(false)
+    Alert.alert(
+      t('accountDeleted'),
+      t('accountDeletedMessage'),
+      [
+        {
+          text: t('okText'),
+          onPress: handleDeletedAccountConfirmation
+        }
+      ],
+      { cancelable: false }
+    )
   }
   const onErrorDeactivate = (error) => {
     if (error.graphQLErrors) {

--- a/enatega-multivendor-app/src/screens/Settings/SettingsV2.js
+++ b/enatega-multivendor-app/src/screens/Settings/SettingsV2.js
@@ -7,7 +7,8 @@ import {
   Linking,
   StatusBar,
   ActivityIndicator,
-  Text
+  Text,
+  Alert
 } from 'react-native'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import * as Updates from 'expo-updates'
@@ -156,16 +157,30 @@ function Settings(props) {
     checkPermission()
   }, [props.navigation, languageName])
 
+  async function handleDeletedAccountConfirmation() {
+    await logout()
+    navigation.reset({
+      routes: [{ name: 'Main' }]
+    })
+  }
+
   async function deactivatewithemail() {
     try {
       await deactivated({
         variables: { isActive: false, email: profile.email }
       })
-      logout()
-      navigation.reset({
-        routes: [{ name: 'Main' }]
-      })
-      FlashMessage({ message: t('accountDeactivated') })
+      modalizeRef.current.close()
+      Alert.alert(
+        t('accountDeleted'),
+        t('accountDeletedMessage'),
+        [
+          {
+            text: t('okText'),
+            onPress: handleDeletedAccountConfirmation
+          }
+        ],
+        { cancelable: false }
+      )
     } catch (error) {
       console.error('Error during deactivation mutation:', error)
     }

--- a/enatega-multivendor-app/translations/en.js
+++ b/enatega-multivendor-app/translations/en.js
@@ -298,6 +298,8 @@ export const en = {
   numberAddedAlert: 'Phone number has been added successfully!.',
   itemNotAvailable: 'One or more item is not available',
   accountDeactivated: 'Account Deactivated',
+  accountDeleted: 'Account Deleted',
+  accountDeletedMessage: 'Your account has been deleted successfully.',
   addressUpdated: 'Address Updated',
   errorOccured: 'An error occured. Please try again ',
   otpForResetPassword: 'OTP for reset password has been sent to your email.',


### PR DESCRIPTION
## Summary
- Show a confirmation popup after account deletion succeeds.
- Apply the success popup to both the Profile and Settings delete-account flows.
- Add English copy for the successful deletion message.

## Testing
- `git diff --check`
- `npx eslint src/screens/Profile/Profile.js src/screens/Settings/SettingsV2.js translations/en.js` currently reports existing lint issues in these files and translation duplicates; the new alert code is used.

Fixes #1556