### PR TITLE
Hide wallet amount helper text after input

### DIFF
--- a/enatega-multivendor-rider/src/screens/Withdraw/Withdraw.js
+++ b/enatega-multivendor-rider/src/screens/Withdraw/Withdraw.js
@@ -32,6 +32,8 @@ const Withdraw = () => {
   } = useWithdrawRequest()
 
   const { t } = useTranslation()
+  const hasAmount = amount.trim().length > 0
+
   return (
     <WalletScreenBg backBtn>
       {requestSent ? (
@@ -62,26 +64,22 @@ const Withdraw = () => {
               amount={dataProfile.rider.currentWalletAmount.toFixed(2)}
             />
             <View style={styles.inputView}>
-              {/* <TextInput
-                placeholder="$0.00"
-                value={amount}
-                onChangeText={text => setAmount(parseFloat(text))}
-                style={[styles.textInput, error && styles.errorInput]}
-              /> */}
               <TextInput
                 placeholder="$0.00"
-                value={amount !== undefined ? amount : ''}
-                onChangeText={(text) => setAmount(parseFloat(text))}
+                value={amount}
+                onChangeText={setAmount}
                 style={[styles.textInput, error && styles.errorInput]}
               />
-              <TextDefault
-                style={styles.inputText}
-                H4
-                textColor={
-                  error ? colors.textErrorColor : colors.fontSecondColor
-                }>
-                {error || t('enteramount')}
-              </TextDefault>
+              {(error || !hasAmount) && (
+                <TextDefault
+                  style={styles.inputText}
+                  H4
+                  textColor={
+                    error ? colors.textErrorColor : colors.fontSecondColor
+                  }>
+                  {error || t('enteramount')}
+                </TextDefault>
+              )}
             </View>
             <View style={styles.btnView}>
               {loading ? (

--- a/enatega-multivendor-rider/src/screens/Withdraw/useWithdrawRequest.js
+++ b/enatega-multivendor-rider/src/screens/Withdraw/useWithdrawRequest.js
@@ -1,5 +1,6 @@
 import { Dimensions } from 'react-native'
 import { useContext, useState, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { gql, useMutation } from '@apollo/client'
 import { createWithdrawRequest } from '../../apollo/mutations'
@@ -11,12 +12,11 @@ import { MIN_WITHDRAW_AMOUNT } from '../../utilities/constants'
 const WITHDRAW_REQUEST = gql`
   ${createWithdrawRequest}
 `
-import {useTranslation} from 'react-i18next'
 
 export const useWithdrawRequest = () => {
-  const {t} = useTranslation()
+  const { t } = useTranslation()
   const [error, setError] = useState(false)
-  const [amount, setAmount] = useState("")
+  const [amount, setAmount] = useState('')
   const [requestSent, setRequestSent] = useState(false)
   const { height } = Dimensions.get('window')
   const { dataProfile } = useContext(UserContext)
@@ -61,6 +61,11 @@ export const useWithdrawRequest = () => {
     })
   }
 
+  function onChangeAmount(amount) {
+    setAmount(amount)
+    if (error) setError('')
+  }
+
   function onSubmit() {
     if (validateForm()) {
       mutate({
@@ -74,7 +79,7 @@ export const useWithdrawRequest = () => {
     dataProfile,
     error,
     amount,
-    setAmount,
+    setAmount: onChangeAmount,
     requestSent,
     height,
     loading,


### PR DESCRIPTION
## Summary
- Hide the withdraw amount helper text once the rider enters an amount.
- Show the helper text again when the amount field is empty.
- Clear stale validation text as soon as the rider edits the amount.

## Testing
- `git diff --check`
- `npx eslint src/screens/Withdraw/Withdraw.js src/screens/Withdraw/useWithdrawRequest.js`

Fixes #370
