### PR TITLE
Confirm address deletion before removing

### DIFF
--- a/enatega-multivendor-app/src/screens/Addresses/Addresses.js
+++ b/enatega-multivendor-app/src/screens/Addresses/Addresses.js
@@ -4,7 +4,8 @@ import {
   TouchableOpacity,
   FlatList,
   StatusBar,
-  Platform
+  Platform,
+  Alert
 } from 'react-native'
 import { NetworkStatus, useMutation } from '@apollo/client'
 import {
@@ -52,9 +53,27 @@ function Addresses() {
   const currentTheme = theme[themeContext.ThemeValue]
   const { t } = useTranslation()
 
-    function onCompleted() {
-      FlashMessage({ message: t('addressDeletedMessage') })
-    }
+  function onCompleted() {
+    FlashMessage({ message: t('addressDeletedMessage') })
+  }
+
+  function confirmDeleteAddress(id) {
+    Alert.alert(
+      t('deleteAddress'),
+      t('deleteAddressConfirmation'),
+      [
+        {
+          text: t('Cancel'),
+          style: 'cancel'
+        },
+        {
+          text: t('deleteAddress'),
+          onPress: () => mutate({ variables: { id } })
+        }
+      ],
+      { cancelable: true }
+    )
+  }
 
   useFocusEffect(() => {
     if (Platform.OS === 'android') {
@@ -204,7 +223,7 @@ function Addresses() {
                   activeOpacity={0.7}
                   disabled={loadingMutation}
                   onPress={() => {
-                    mutate({ variables: { id: address._id } })
+                    confirmDeleteAddress(address._id)
                   }}
                 >
                   

--- a/enatega-multivendor-app/src/screens/Addresses/AddressesV2.js
+++ b/enatega-multivendor-app/src/screens/Addresses/AddressesV2.js
@@ -6,7 +6,8 @@ import {
   StatusBar,
   Platform,
   Text,
-  ScrollView
+  ScrollView,
+  Alert
 } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useMutation } from '@apollo/client'
@@ -30,6 +31,7 @@ import { alignment } from '../../utils/alignment'
 import { useNavigation, useFocusEffect } from '@react-navigation/native'
 import EmptyAddress from '../../assets/SVG/imageComponents/EmptyAddress'
 import analytics from '../../utils/analytics'
+import { FlashMessage } from '../../ui/FlashMessage/FlashMessage'
 import navigationService from '../../routes/navigationService'
 import { HeaderBackButton } from '@react-navigation/elements'
 import CustomHomeIcon from '../../assets/SVG/imageComponents/CustomHomeIcon'
@@ -45,12 +47,37 @@ function Addresses() {
   const Analytics = analytics()
 
   const navigation = useNavigation()
-  const [mutate, { loading: loadingMutation }] = useMutation(DELETE_ADDRESS)
+  const [mutate, { loading: loadingMutation }] = useMutation(DELETE_ADDRESS, {
+    onCompleted
+  })
   const { profile } = useContext(UserContext)
   const themeContext = useContext(ThemeContext)
   const currentTheme = theme[themeContext.ThemeValue]
   const inset = useSafeAreaInsets()
   const { t } = useTranslation()
+
+  function onCompleted() {
+    FlashMessage({ message: t('addressDeletedMessage') })
+  }
+
+  function confirmDeleteAddress(id) {
+    Alert.alert(
+      t('deleteAddress'),
+      t('deleteAddressConfirmation'),
+      [
+        {
+          text: t('Cancel'),
+          style: 'cancel'
+        },
+        {
+          text: t('deleteAddress'),
+          onPress: () => mutate({ variables: { id } })
+        }
+      ],
+      { cancelable: true }
+    )
+  }
+
   useFocusEffect(() => {
     if (Platform.OS === 'android') {
       StatusBar.setBackgroundColor(currentTheme.headerBackground)
@@ -201,7 +228,7 @@ function Addresses() {
                     activeOpacity={0.7}
                     disabled={loadingMutation}
                     onPress={() => {
-                      mutate({ variables: { id: address._id } })
+                      confirmDeleteAddress(address._id)
                     }}>
                     <EvilIcons
                       name="trash"

--- a/enatega-multivendor-app/translations/en.js
+++ b/enatega-multivendor-app/translations/en.js
@@ -519,6 +519,8 @@ export const en = {
   LowestRating: 'Lowest Rating',
   cartAddresses: 'Cart Addresses',
   addressDeletedMessage: 'Address deleted!',
+  deleteAddress: 'Delete Address',
+  deleteAddressConfirmation: 'Are you sure you want to delete this address?',
   logoutMessage: 'Successfully logged out',
   somethingWentWrong: 'Something went wrong',
   checkInternet: 'Check your internet connection',


### PR DESCRIPTION
## Summary
- Ask users to confirm before deleting an address from the customer app.
- Keep the existing address deleted success message after the delete mutation completes.
- Add the same success message behavior to the V2 address screen.

## Testing
- `git diff --check`
- `npx eslint src/screens/Addresses/Addresses.js src/screens/Addresses/AddressesV2.js translations/en.js` reports existing lint issues in these files, including duplicate translation keys and pre-existing style errors.

Fixes #1541
